### PR TITLE
Suppress byte-compile warnings

### DIFF
--- a/emacs-workspaces.el
+++ b/emacs-workspaces.el
@@ -55,6 +55,9 @@
 (require 'seq)
 (require 'cl-lib)
 
+(declare-function magit-init "magit-status")
+(declare-function magit-status-setup-buffer "magit-status")
+
 ;;;; Variables
 
 (defcustom emacs-workspaces-workspace-create-permitted-buffer-names '("*scratch*")


### PR DESCRIPTION
```
emacs-workspaces.el:226:10: Warning: the function ‘magit-status-setup-buffer’
    is not known to be defined.
emacs-workspaces.el:175:14: Warning: the function ‘magit-init’ is not known to
    be defined.
```